### PR TITLE
Minor Typo in Example Code of Classifier Dashboard

### DIFF
--- a/index_layout.py
+++ b/index_layout.py
@@ -62,7 +62,7 @@ from explainerdashboard.datasets import titanic_survive, feature_descriptions
 X_train, y_train, X_test, y_test = titanic_survive()
 model = RandomForestClassifier(n_estimators=50, max_depth=10).fit(X_train, y_train)
 
-explainer = RandomForestClassifierExplainer(model, X_test, y_test, 
+explainer = ClassifierExplainer(model, X_test, y_test, 
                                cats=['Sex', 'Deck', 'Embarked'],
                                descriptions=feature_descriptions,
                                labels=['Not survived', 'Survived'])


### PR DESCRIPTION
Hi, 
I was exploring explainerdashboard and found this intuitive example where you integrated different titanic dashboards. While I was looking at the code of the classifier dashboard, I found that there is no  ```RandomForestClassifierExplainer``` in the documentation and it is mistaken for ```ClassifierExplainer```. 

This PR resolves this issue! 
![image](https://user-images.githubusercontent.com/43691873/103227445-67a6d780-4954-11eb-8485-9a59a07e8844.png)
